### PR TITLE
Inform StaticModule that the editor is open/close

### DIFF
--- a/src/Core/StaticObjects/StaticModule.cs
+++ b/src/Core/StaticObjects/StaticModule.cs
@@ -14,8 +14,8 @@ namespace KerbalKonstructs.Core
 		
 		public virtual void StaticObjectUpdate() {}
 
-		public virtual void StaticObjectEditorOpen () {}
+        public virtual void StaticObjectEditorOpen () {}
 
-		public virtual void StaticObjectEditorClose () {}
+        public virtual void StaticObjectEditorClose () {}
 	}
 }

--- a/src/Core/StaticObjects/StaticModule.cs
+++ b/src/Core/StaticObjects/StaticModule.cs
@@ -14,8 +14,8 @@ namespace KerbalKonstructs.Core
 		
 		public virtual void StaticObjectUpdate() {}
 
-        public virtual void StaticObjectEditorOpen () {}
+		public virtual void StaticObjectEditorOpen () {}
 
-        public virtual void StaticObjectEditorClose () {}
+		public virtual void StaticObjectEditorClose () {}
 	}
 }

--- a/src/Core/StaticObjects/StaticModule.cs
+++ b/src/Core/StaticObjects/StaticModule.cs
@@ -13,5 +13,9 @@ namespace KerbalKonstructs.Core
 		public Dictionary<String, String> moduleFields = new Dictionary<string,string>();
 		
 		public virtual void StaticObjectUpdate() {}
+
+		public virtual void StaticObjectEditorOpen () {}
+
+		public virtual void StaticObjectEditorClose () {}
 	}
 }

--- a/src/Editor/StaticsEditorGUI.cs
+++ b/src/Editor/StaticsEditorGUI.cs
@@ -139,7 +139,7 @@ namespace KerbalKonstructs.UI
             KerbalKonstructs.instance.DeletePreviewObject();
             base.Close();
 
-            // Notify the modules the editor is open
+            // Notify the modules the editor is close
             foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
                 if (staticInstance.isActive) {
                     foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {

--- a/src/Editor/StaticsEditorGUI.cs
+++ b/src/Editor/StaticsEditorGUI.cs
@@ -139,14 +139,14 @@ namespace KerbalKonstructs.UI
             KerbalKonstructs.instance.DeletePreviewObject();
             base.Close();
 
-			// Notify the modules the editor is open
-			foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
-				if (staticInstance.isActive) {
-					foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {
-						module.StaticObjectEditorClose ();
-					}
-				}
-			}
+            // Notify the modules the editor is open
+            foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
+                if (staticInstance.isActive) {
+                    foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {
+                        module.StaticObjectEditorClose ();
+                    }
+                }
+            }
         }
 
         public void drawEditor()

--- a/src/Editor/StaticsEditorGUI.cs
+++ b/src/Editor/StaticsEditorGUI.cs
@@ -122,6 +122,15 @@ namespace KerbalKonstructs.UI
             allStaticModels = StaticDatabase.allStaticModels;
             base.Open();
             EditorGUI.instance.Open();
+
+			// Notify the modules the editor is open
+			foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
+				if (staticInstance.isActive) {
+					foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {
+						module.StaticObjectEditorOpen ();
+					}
+				}
+			}
         }
 
         public override void Close()
@@ -129,6 +138,15 @@ namespace KerbalKonstructs.UI
             EditorGUI.instance.Close();
             KerbalKonstructs.instance.DeletePreviewObject();
             base.Close();
+
+			// Notify the modules the editor is close
+			foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
+				if (staticInstance.isActive) {
+					foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {
+						module.StaticObjectEditorClose ();
+					}
+				}
+			}
         }
 
         public void drawEditor()

--- a/src/Editor/StaticsEditorGUI.cs
+++ b/src/Editor/StaticsEditorGUI.cs
@@ -123,14 +123,14 @@ namespace KerbalKonstructs.UI
             base.Open();
             EditorGUI.instance.Open();
 
-			// Notify the modules the editor is open
-			foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
-				if (staticInstance.isActive) {
-					foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {
-						module.StaticObjectEditorOpen ();
-					}
-				}
-			}
+            // Notify the modules the editor is open
+            foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
+                if (staticInstance.isActive) {
+                    foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {
+                        module.StaticObjectEditorOpen ();
+                    }
+                }
+            }
         }
 
         public override void Close()
@@ -139,7 +139,7 @@ namespace KerbalKonstructs.UI
             KerbalKonstructs.instance.DeletePreviewObject();
             base.Close();
 
-			// Notify the modules the editor is close
+			// Notify the modules the editor is open
 			foreach (StaticInstance staticInstance in StaticDatabase.allStaticInstances) {
 				if (staticInstance.isActive) {
 					foreach (StaticModule module in staticInstance.gameObject.GetComponents<StaticModule> ()) {


### PR DESCRIPTION
Add method to inform the staticModule the editor is open, useful to stop logic within the staticModule when unneeded.
[It has been discussed on the forum](https://forum.kerbalspaceprogram.com/index.php?/topic/151818-131-kerbal-konstructs-131-07102017/&do=findComment&comment=3283208)


BTW : StaticModule use 1 tab as indent but StaticEditorGUI use 4 spaces....